### PR TITLE
Add replicas to Deployment

### DIFF
--- a/demo-01/manifests/deployment.yaml
+++ b/demo-01/manifests/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: echoenv
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: echoenv


### PR DESCRIPTION
To make the `echoenv` application more resilient, increase the replica count to three.